### PR TITLE
feat: migrate to `tree-sitter.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,15 +44,5 @@
     "glob": "^11.0.0",
     "tree-sitter-cli": "^0.24.0",
     "prebuildify": "^6.0.1"
-  },
-  "tree-sitter": [
-    {
-      "scope": "source.mlir",
-      "file-types": [
-        "mlir"
-      ],
-      "highlights": "queries/highlights.scm",
-      "locals": "queries/locals.scm"
-    }
-  ]
+  }
 }

--- a/tree-sitter.json
+++ b/tree-sitter.json
@@ -1,0 +1,36 @@
+{
+  "grammars": [
+    {
+      "name": "mlir",
+      "camelcase": "Mlir",
+      "scope": "source.mlir",
+      "path": ".",
+      "file-types": [
+        "mlir"
+      ],
+      "highlights": "queries/highlights.scm",
+      "locals": "queries/locals.scm"
+    }
+  ],
+  "metadata": {
+    "version": "0.0.1",
+    "license": "Apache-2.0",
+    "description": "Tree sitter grammar for MLIR",
+    "authors": [
+      {
+        "name": "Ramkumar Ramachandra"
+      }
+    ],
+    "links": {
+      "repository": "https://github.com/tree-sitter/tree-sitter-mlir"
+    }
+  },
+  "bindings": {
+    "c": true,
+    "go": true,
+    "node": true,
+    "python": true,
+    "rust": true,
+    "swift": true
+  }
+}


### PR DESCRIPTION
Hey :wave: I'm putting up this PR because this file will be a requirement in 0.25, and this is one of the few remaining grammars out there that hasn't migrated, thanks.